### PR TITLE
Update install-cli-deps.sh

### DIFF
--- a/install-cli-deps.sh
+++ b/install-cli-deps.sh
@@ -8,7 +8,7 @@ read -r -d '' packages <<- EOM
     python3-argcomplete
     python3-colorama
     python3-clint
-    python3-pyyaml
+    python3-PyYAML
     python3-requests
     python3-requests-toolbelt
 EOM
@@ -19,4 +19,3 @@ for package in $packages; do
 done
 
 sudo dnf install $@ $deps
-    


### PR DESCRIPTION
python3-pyyaml has to be changed to python3-PyYAML, otherwise when you invoke install-cli-deps.sh script, you will a message "Error: Unable to find a match".

[fedora@fedora sssd-test-suite]$ ./install-cli-deps.sh
Last metadata expiration check: 3:02:27 ago on Fri 19 Jul 2019 11:20:19 AM UTC.
   Maybe you meant: python3-PyYAML
No match for argument: python3-pyyaml
Package python3-requests-2.13.0-1.fc26.noarch is already installed, skipping.
Error: Unable to find a match