### PR TITLE
Update provision configuration

### DIFF
--- a/provision/roles/host/tasks/generic.yml
+++ b/provision/roles/host/tasks/generic.yml
@@ -7,7 +7,8 @@
     - dnsmasq
     - gcc
     - libguestfs-tools-c
-    - libselinux-python
+    # Bellow moved to Fedora-version specified config
+    #- libselinux-python
     - libselinux-python3
     - libvirt
     - libvirt-daemon-kvm

--- a/provision/roles/packages/tasks/CentOS7.yml
+++ b/provision/roles/packages/tasks/CentOS7.yml
@@ -14,6 +14,7 @@
     - git
     - ldb-tools
     - NetworkManager
+    - libselinux-python
     - openldap-clients
     - screen
     - systemtap

--- a/provision/roles/packages/tasks/Debian10.yml
+++ b/provision/roles/packages/tasks/Debian10.yml
@@ -15,6 +15,7 @@
     - python3-selinux
     - mc
     - network-manager
+    - libselinux-python
     - ldap-utils
     - screen
     - systemtap

--- a/provision/roles/packages/tasks/Fedora27.yml
+++ b/provision/roles/packages/tasks/Fedora27.yml
@@ -17,6 +17,7 @@
     - gdb
     - git
     - ldb-tools
+    - libselinux-python
     - libselinux-python3
     - mc
     - NetworkManager

--- a/provision/roles/packages/tasks/RedHat7.yml
+++ b/provision/roles/packages/tasks/RedHat7.yml
@@ -14,6 +14,7 @@
     - git
     - ldb-tools
     - NetworkManager
+    - libselinux-python
     - openldap-clients
     - screen
     - systemtap


### PR DESCRIPTION
Starting from Fedora 31 libselinux-python is no longer available.
I moved it from generic packages list to the distro specific
packages list.