### PR TITLE
Fix vagrant plugins installation

### DIFF
--- a/cli/util/actor.py
+++ b/cli/util/actor.py
@@ -44,12 +44,7 @@ class TestSuiteActor(Actor):
         argv = argv if argv is not None else []
 
         env = {
-            'ANSIBLE_SSH_ARGS': '-o UserKnownHostsFile=/dev/null '
-                                '-o IdentitiesOnly=yes '
-                                '-o ControlMaster=auto '
-                                '-o ControlPersist=60s '
-                                '-o ServerAliveInterval=15',
-            'ANSIBLE_HOST_KEY_CHECKING': 'false'
+            'ANSIBLE_CONFIG': '{}/provision/ansible.cfg'.format(self.root_dir),
         }
 
         limit = ','.join(limit) if limit else 'all'
@@ -59,7 +54,6 @@ class TestSuiteActor(Actor):
 
         args = [
             '--limit', limit,
-            '--inventory-file', '{}/provision/inventory.yml'.format(self.root_dir),
             *argv,
             '{}/provision/{}'.format(self.root_dir, playbook)
         ]

--- a/docs/tips.md
+++ b/docs/tips.md
@@ -48,3 +48,54 @@ If you need only the Linux machines, you can use:
 $ ./sssd-test-suite up ipa ldap client -s
 $ ./sssd-test-suite provision enroll ipa ldap client
 ```
+
+## Troubleshooting Ansible Scripts
+
+If we want to run the playbooks with more verbosity level, do the below:
+
+```bash
+$ ANSIBLE_VERBOSITY="8" ./sssd-test-suite provision host --pool "$POOL_DIR"
+```
+
+or just:
+
+```bash
+$ export ANSIBLE_VERBOSITY="8"
+```
+
+and run as normal.
+
+If it were needed, the ansible script can be launched directly from the
+**provision** directory as showed below:
+
+```bash
+# With no verbose
+$ ansible-playbook --extra-vars "LIBVIRT_STORAGE=$POOL_DIR" --ask-become-pass ./prepare-host.yml
+
+# With verbose
+$ ansible-playbook --extra-vars "LIBVIRT_STORAGE=$POOL_DIR" --ask-become-pass ./prepare-host.yml -vvv
+
+# With even more verbose
+$ ansible-playbook --extra-vars "LIBVIRT_STORAGE=$POOL_DIR" --ask-become-pass ./prepare-host.yml -vvvvvvvv
+```
+
+> It is important to run the playbook from the `provision` directory, because ansible will use
+> by default the `ansible.cfg ` file found into the current directory.
+
+To run from any directory we have to specify the `ANSIBLE_CONFIG` environmnet variable as below:
+
+```bash
+$ ANSIBLE_CONFIG=./provision/ansible.cfg ansible-playbook --extra-vars "LIBVIRT_STORAGE=$POOL_DIR" --ask-become-pass ./provision/prepare-host.yml -vvv
+```
+
+---
+
+If we want to run a role from the command line for testing purpose, we can launch do the below,
+from the provision directory:
+
+```shell
+ansible localhost -K -m include_role -a "name=dnsclient" --extra-vars @variables.yml
+```
+
+In this case, execute role **dnsclient** for **localhost** using the variables
+stored at `variables.yml` file.

--- a/install-cli-deps.sh
+++ b/install-cli-deps.sh
@@ -19,4 +19,4 @@ for package in $packages; do
 done
 
 sudo dnf install $@ $deps
-    
+

--- a/provision/ansible.cfg
+++ b/provision/ansible.cfg
@@ -1,0 +1,26 @@
+# Configuration file created for Ansible 2.9
+
+[defaults]
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-become
+become_ask_pass = True
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-host-list
+inventory = ./inventory.yml
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-load-callback-plugins
+bin_ansible_callbacks = True
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-stdout-callback
+stdout_callback = yaml
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#default-callback-whitelist
+#callback_whitelist = timer, profile_roles
+
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#host-key-checking
+host_key_checking = False
+
+
+
+[ssh_connection]
+# https://docs.ansible.com/ansible/latest/reference_appendices/config.html#ansible-ssh-args
+ssh_args = -o UserKnownHostsFile=/dev/null -o IdentitiesOnly=yes -o ControlMaster=auto -o ControlPersist=60s -o ServerAliveInterval=15

--- a/provision/roles/enroll-client/tasks/ad.yml
+++ b/provision/roles/enroll-client/tasks/ad.yml
@@ -8,15 +8,17 @@
 - name: Join to Active Directory domain
   become: True
   shell: |
-    echo vagrant | realm join {{ ad.domain | quote }} || exit $?
+    echo vagrant | realm join -v {{ ad.domain | upper | quote }} || exit $?
+    echo vagrant | kinit {{ ad.kerberos.username }} || exit $?
     touch /etc/sssd/ad_enrolled || exit $?
   register: client_ad_installation
-  args:
-    creates: /etc/sssd/ad_enrolled
+  # args:
+  #   creates: /etc/sssd/ad_enrolled
 
 - name: Copy AD keytab to local folder
   become: True
   copy:
+    force: True
     src: /etc/krb5.keytab
     dest: '/etc/sssd/ad.keytab'
     remote_src: yes
@@ -29,5 +31,14 @@
     src: '/etc/sssd/ad.keytab'
     dest: '/shared/enrollment/{{ inventory_hostname }}/ad.keytab'
     remote_src: yes
+  when: client_ad_installation.changed
 
-- include_tasks: 'cleanup.yml'
+- name: Create symbolic link
+  become: True
+  file:
+    force: yes
+    path: '/etc/krb5.keytab'
+    src: '/shared/enrollment/{{ inventory_hostname }}/ad.keytab'
+    state: link
+
+# - include_tasks: 'cleanup.yml'

--- a/provision/roles/enroll-client/tasks/cleanup.yml
+++ b/provision/roles/enroll-client/tasks/cleanup.yml
@@ -1,8 +1,8 @@
-- name: Cleanup after join
-  become: True
-  file:
-    path: '{{ item }}'
-    state: absent
-  with_items:
-  - /etc/krb5.keytab
-  - /etc/sssd/sssd.conf
+---
+# - name: Cleanup after join
+#   become: True
+#   file:
+#     path: '{{ item }}'
+#     state: absent
+#   with_items:
+#   - /etc/krb5.keytab

--- a/provision/roles/enroll-client/templates/sssd.conf
+++ b/provision/roles/enroll-client/templates/sssd.conf
@@ -2,7 +2,7 @@
 config_file_version = 2
 services = nss, pam, ifp, sudo
 debug_level = 0x3ff0
-domains = ldap.vm
+domains = ldap.vm,ad.vm
 user = root
 
 [nss]

--- a/provision/roles/host/tasks/generic.yml
+++ b/provision/roles/host/tasks/generic.yml
@@ -6,20 +6,20 @@
     - vagrant
 
 # dnf install vagrant pulls in vagrant-libvirt which is not desirable
-- name: Remove vagrant plugins installed through dnf
+- name: Remove vagrant plugins installed through dnf and rubygem-fog-core gem
   become: True
   package:
     state: absent
     name:
-    - vagrant-libvirt
-    - vagrant-sshfs
+      - vagrant-libvirt
+      - vagrant-sshfs
+      - rubygem-fog-core
 
 - name: Install packages needed for virtualization and vagrant plugins
   become: True
   package:
     state: present
     name:
-    - ansible
     - dnsmasq
     - gcc
     - libguestfs-tools-c
@@ -39,7 +39,11 @@
     - ruby-devel
     - rubygem-nokogiri
     - rubygem-ruby-libvirt
+    - rdesktop
+    - ldapvi
+    - openldap-clients
 
+# The order of the plugins matter here. Install first vagrant-libvirt
 - name: Install required vagrant plugins
   shell: |
     vagrant plugin list | grep -w '{{ plugin }}\s'
@@ -55,8 +59,8 @@
   loop_control:
     loop_var: plugin
   with_items:
-  - winrm
-  - winrm-fs
-  - winrm-elevated
-  - vagrant-libvirt
-  - vagrant-sshfs
+    - vagrant-libvirt
+    - vagrant-sshfs
+    - winrm
+    - winrm-fs
+    - winrm-elevated

--- a/provision/roles/win-schema/tasks/main.yml
+++ b/provision/roles/win-schema/tasks/main.yml
@@ -5,9 +5,10 @@
   with_items:
   - sudo
 
+# https://docs.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2012-r2-and-2012/cc731033(v=ws.11)
 - name: Install additional schemas
   win_shell: |
-    ldifde -i -f C:\{{ item }}.schema -c dc=X {{ suffix }}
+    ldifde -i -s localhost -f C:\{{ item }}.schema -c "DC=X" "{{ suffix }}"
   register: schema
   failed_when: schema.rc != 0 and schema.stdout is not search('ENTRY_EXISTS')
   changed_when: schema.rc == 0

--- a/provision/variables.yml
+++ b/provision/variables.yml
@@ -1,63 +1,60 @@
+---
 # Network information
-network: {
-  base_ip: 192.168.100,
-  reverse_zone: 100.168.192.in-addr.arpa,
-  dns_tld: vm,
-  dns_server: '192.168.100.10'
-}
+network:
+  base_ip: "192.168.100"
+  reverse_zone: "100.168.192.in-addr.arpa"
+  dns_tld: "vm"
+  dns_server: "192.168.100.10"
 
 # IPA server configuration
-ipa: {
-  ip: '{{ network.base_ip }}.10',
-  domain: 'ipa.{{ network.dns_tld }}',
-  hostname: 'master',
-  fqn: 'master.ipa.{{ network.dns_tld }}',
-  netbios: 'IPA',
-  password: '123456789'
-}
+ipa:
+  ip: "{{ network.base_ip }}.10"
+  domain: "ipa.{{ network.dns_tld }}"
+  hostname: "master"
+  fqn: "master.ipa.{{ network.dns_tld }}"
+  netbios: "IPA"
+  password: "123456789"
 
 # LDAP server configuration
-ldap: {
-  ip: '{{ network.base_ip }}.20',
-  domain: 'ldap.{{ network.dns_tld }}',
-  hostname: 'master',
-  fqn: 'master.ldap.{{ network.dns_tld }}',
-  suffix: 'dc=ldap,dc={{ network.dns_tld }}',
-  bind: {
-    dn: 'cn=Directory Manager',
-    password: '123456789'
-  }
-}
+ldap:
+  ip: "{{ network.base_ip }}.20"
+  domain: "ldap.{{ network.dns_tld }}"
+  hostname: "master"
+  fqn: "master.ldap.{{ network.dns_tld }}"
+  suffix: "dc=ldap,dc={{ network.dns_tld }}"
+  bind:
+    dn: "cn=Directory Manager"
+    password: "123456789"
 
 # AD server configuration
-ad: {
-  ip: '{{ network.base_ip }}.110',
-  domain: 'ad.{{ network.dns_tld }}',
-  hostname: 'root-dc',
-  fqn: 'root-dc.ad.{{ network.dns_tld }}',
-  netbios: 'ADROOT',
-  forest_mode: WinThreshold,
-  domain_mode: WinThreshold,
-  safe_password: Secret123,
-  suffix: 'dc=ad,dc={{ network.dns_tld }}'
-}
+ad:
+  ip: "{{ network.base_ip }}.110"
+  domain: "ad.{{ network.dns_tld }}"
+  hostname: "root-dc"
+  fqn: "root-dc.ad.{{ network.dns_tld }}"
+  netbios: "ADROOT"
+  forest_mode: "WinThreshold"
+  domain_mode: "WinThreshold"
+  safe_password: "Secret123"
+  suffix: "dc=ad,dc={{ network.dns_tld }}"
+  kerberos:
+    # username: "Administrator@{{ ad.domain | upper }}"
+    username: "Administrator@AD.VM"
 
 # AD child server configuration
-ad_child: {
-  ip: '{{ network.base_ip }}.120',
-  domain: 'child.{{ ad.domain }}',
-  hostname: 'child-dc',
-  fqn: 'child-dc.child.{{ ad.domain }}',
-  netbios: 'ADCHILD',
-  safe_password: Secret123,
-  suffix: 'dc=child,{{ ad.suffix }}'
-}
+ad_child:
+  ip: "{{ network.base_ip }}.120"
+  domain: "child.{{ ad.domain }}"
+  hostname: "child-dc"
+  fqn: "child-dc.child.{{ ad.domain }}"
+  netbios: "ADCHILD"
+  safe_password: "Secret123"
+  suffix: "dc=child,{{ ad.suffix }}"
 
 # Client configuration
-client: {
-  ip: '{{ network.base_ip }}.30',
-  domain: 'client.{{ network.dns_tld }}',
-  hostname: 'master',
-  fqn: 'master.client.{{ network.dns_tld }}',
-  child_fqn: 'child.client.{{ network.dns_tld }}'
-}
+client:
+  ip: "{{ network.base_ip }}.30"
+  domain: client.{{ network.dns_tld }}
+  hostname: "master"
+  fqn: "master.client.{{ network.dns_tld }}"
+  child_fqn: "child.client.{{ network.dns_tld }}"

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,8 @@ Now you can:
 * ssh to the ipa machine with `./sssd-test-suite ssh ipa`
 * open ipa web interface at `https://master.ipa.vm`
 
+> See also [User accounts](docs/guests.md#user-accounts)
+
 ### I want to try SSSD with native LDAP
 
 ```bash
@@ -57,8 +59,10 @@ $ ./sssd-test-suite up client ldap && ./sssd-test-suite provision enroll client 
 Now you can:
 * ssh to the client machine with `./sssd-test-suite ssh client`
 * ssh to the ldap machine with `./sssd-test-suite ssh ldap`
-* access LDAP server at `ldap://master.ldap.vm`
+* access LDAP server at `ldap://master.ldap.vm` with `ldapvi --discover --host master.ldap.vm`
 * load example data to the server with `./sssd-test-suite provision ldap --clear ./provision/ldif/basic.ldif`
+
+> See also [User accounts](docs/guests.md#user-accounts)
 
 ### I want to try SSSD with Active Directory
 
@@ -69,12 +73,17 @@ $ cd sssd-test-suite
 $ ./install-cli-deps.sh
 $ ./sssd-test-suite provision host --pool "$POOL_DIR"
 $ cp ./configs/sssd-f30.json config.json
-$ ./sssd-test-suite up client ad && ./sssd-test-suite provision enroll client ad
+$ ./sssd-test-suite up client ad && ./sssd-test-suite provision guest ad && ./sssd-test-suite provision enroll client ad
 ```
 
 Now you can:
 * ssh to the client machine with `./sssd-test-suite ssh client`
-* open remote desktop of ad machine with `./sssd-test-suite rdp ad -- -g 90%`
+* open remote desktop of ad machine with `./sssd-test-suite rdp ad -- -g 90%` or `rdesktop 192.168.100.110`
+
+> See also [User accounts](docs/guests.md#user-accounts)
+
+> The first time connecting by rdesktop you could need to accept the certificate.
+> Run by hand the first time, later you can launch with `sssd-test-suite rdp ad`.
 
 ### I want to try SSSD with FreeIPA, LDAP and Active Directory (including child domain)
 
@@ -92,9 +101,10 @@ Now you can:
 * ssh to the client machine with `./sssd-test-suite ssh client`
 * ssh to the ldap machine with `./sssd-test-suite ssh ldap`
 * ssh to the ipa machine with `./sssd-test-suite ssh ipa`
-* open remote desktop of ad machine with `./sssd-test-suite rdp ad -- -g 90%`
-* open remote desktop of ad-child machine with `./sssd-test-suite rdp ad-child -- -g 90%`
+* open remote desktop of ad machine with `./sssd-test-suite rdp ad -- -g 90%` or `rdesktop 192.168.100.110`
+* open remote desktop of ad-child machine with `./sssd-test-suite rdp ad-child -- -g 90%` or `rdesktop 192.168.100.120`
 * open ipa web interface at `https://master.ipa.vm`
-* access LDAP server at `ldap://master.ldap.vm`
+* access LDAP server at `ldap://master.ldap.vm` with `ldapvi --discover --host master.ldap.vm`
 * load example data to the server with `./sssd-test-suite provision ldap --clear ./provision/ldif/basic.ldif`
 
+> See also [User accounts](docs/guests.md#user-accounts)


### PR DESCRIPTION
A few changes included:
- Fix vagrant plugins installation by removing "rubygem-fog-core" package to allow vagrant plugins resolve properly the dependencies when they are installed (now I am not sure if the order they are installed impact on this too; I tested with the order changed when it worked).
- Create ansible.cfg to keep settings there, making easier to launch from the command line similar to how the helper execute it. Change output callback to print messages out in yaml format instead of json format. All this should make easier the troubleshooting in the future.
- Append some tips for troubleshooting in Ansible scripts to the documentation.
- Append "which" and "ansible" package dependencies to install-cli-deps.sh script.
- Install some dependencies to make life easier (rdesktop, ldapvi, openldap-clients). Pretty sure that I am missing here a lot of useful tools.
- Small documentation changes.
- Convert provision/variables.yaml file to yaml format.