### PR TITLE
Change client fqdn to client.ipa.vm

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -29,7 +29,7 @@ machines = [
   Machine.new(
     name: "client",
     type: Machine::LINUX,
-    hostname: "master.client.vm",
+    hostname: "client.vm",
     ip: "192.168.100.30",
     config: config
   ),

--- a/docs/guests.md
+++ b/docs/guests.md
@@ -6,7 +6,7 @@ The `sssd-test-suite` creates the following guests machines:
 |--------------|-------------------|--------------------|-----------------------------------------------------------------|
 | ipa          | `192.168.100.10`  | `master.ipa.vm`    | IPA server                                                      |
 | ldap         | `192.168.100.20`  | `master.ldap.vm`   | TLS ready 389 Directory Server                                  |
-| client       | `192.168.100.30`  | `master.client.vm` | Client machine with configured SSSD                             |
+| client       | `192.168.100.30`  | `client.vm`        | Client machine with configured SSSD                             |
 | ad           | `192.168.100.110` | `root.ad.vm`       | Active Directory Forest root domain                             |
 | ad-child     | `192.168.100.120` | `child.sub.ad.vm`  | Active Directory child domain                                   |
 


### PR DESCRIPTION
Avoid confusion with IPA master, especially when logged in and only a short hostname is visible.