### PR TITLE
provision: use dscreate to install ldap

### DIFF
--- a/provision/roles/enroll-client/templates/sssd.conf
+++ b/provision/roles/enroll-client/templates/sssd.conf
@@ -44,7 +44,7 @@ debug_level = 0x3ff0
 id_provider = ldap
 ldap_uri = _srv_
 ldap_tls_reqcert = demand
-ldap_tls_cacert = /shared/enrollment/ldap/cacert.asc
+ldap_tls_cacert = /shared/enrollment/ldap/ca.crt
 dns_discovery_domain = {{ ldap.domain }}
 
 [domain/ipa.vm]

--- a/provision/roles/enroll-ldap/tasks/main.yml
+++ b/provision/roles/enroll-ldap/tasks/main.yml
@@ -7,6 +7,6 @@
 - name: Copy certificate to shared folder
   become: True
   copy:
-    src: /etc/dirsrv/slapd-master-ldap/cacert.asc
+    src: /etc/dirsrv/slapd-localhost/ca.crt
     dest: '/shared/enrollment/{{ inventory_hostname }}/'
     remote_src: yes

--- a/provision/roles/ldap/tasks/main.yml
+++ b/provision/roles/ldap/tasks/main.yml
@@ -1,64 +1,17 @@
-# Script taken from:
-# https://raw.githubusercontent.com/richm/scripts/master/setupssl2.sh
-- name: Fetch SSL setup script
-  copy:
-    src: setupssl2.sh
-    dest: /tmp/setupssl2.sh
-    mode: 0700
+- name: Create /root/localhost.inf
+  become: True
+  template:
+    src: instance.inf
+    dest: /root/localhost.inf
+    owner: root
+    group: root
+    mode: 0600
 
 - name: Create directory server instance
   become: True
   shell: |
-    /usr/sbin/setup-ds.pl --silent                          \
-      General.SuiteSpotUserID=nobody                        \
-      General.SuiteSpotGroup=nobody                         \
-      slapd.ServerIdentifier={{ ldap.hostname }}-ldap       \
-      slapd.ServerPort=389                                  \
-      slapd.Suffix={{ ldap.suffix | quote }}                \
-      slapd.RootDN={{ ldap.bind.dn | quote }}               \
-      slapd.RootDNPwd={{ ldap.bind.password | quote }}
+    dscreate from-file /root/localhost.inf
   register: installed
   args:
-    creates: '/etc/dirsrv/slapd-{{ ldap.hostname }}-ldap'
+    creates: '/etc/dirsrv/slapd-localhost'
 
-- name: Enable SSL for directory server instance
-  become: True
-  shell: |
-    echo {{ ldap.bind.password | quote }} | /tmp/setupssl2.sh /etc/dirsrv/slapd-{{ ldap.hostname }}-ldap
-    touch  /etc/dirsrv/slapd-{{ ldap.hostname }}-ldap/.setupssl2-done
-  args:
-    creates: '/etc/dirsrv/slapd-{{ ldap.hostname }}-ldap/.setupssl2-done'
-
-- name: Restart directory server
-  become: True
-  service:
-    name: dirsrv.target
-    enabled: yes
-    state: restarted
-  when: installed.changed
-
-- name: Restart directory server instance
-  become: True
-  service:
-    name: dirsrv@master-ldap.service
-    enabled: yes
-    state: restarted
-  when: installed.changed
-
-- name: 'Remove all objects but "cn=Directory Administrators"'
-  shell: |
-    SEARCH=`ldapsearch -x -D '{{ ldap.bind.dn }}' -w {{ ldap.bind.password }} \
-                       -b {{ ldap.suffix }} -s one                            \
-                       '(&(objectClass=*)(!(cn=Directory Administrators)))'`
-    DN=`echo "$SEARCH" | grep dn | sed "s/dn: \(.*\)/'\1'/" | paste -sd " "`
-
-    echo "$SEARCH" | grep numEntries
-    if [ $? -ne 0 ]; then
-      echo "Entries are already removed. Nothing to do."
-      exit 255
-    fi
-
-    eval "ldapdelete -xr -D '{{ ldap.bind.dn }}' -w {{ ldap.bind.password }} $DN"
-  register: result
-  failed_when: "result.rc != 255 and result.rc != 0"
-  changed_when: "result.rc == 0"

--- a/provision/roles/ldap/templates/instance.inf
+++ b/provision/roles/ldap/templates/instance.inf
@@ -1,0 +1,12 @@
+[general]
+config_version = 2
+full_machine_name = {{ ldap.fqn }}
+
+[slapd]
+instance_name = localhost
+root_dn = {{ ldap.bind.dn }}
+root_password = {{ ldap.bind.password }}
+
+[backend-userroot]
+suffix = {{ ldap.suffix }}
+create_suffix_entry = True

--- a/provision/roles/packages/tasks/Fedora32.yml
+++ b/provision/roles/packages/tasks/Fedora32.yml
@@ -45,8 +45,6 @@
     state: present
     name:
     - 389-ds-base
-    - 389-ds-base-legacy-tools
-    - perl
   when: inventory_hostname == 'ldap'
 
 - name: Install Client specific packages


### PR DESCRIPTION
The old perl script was deprecated for some time and removed from Fedora
33 and newer.