### PR TITLE
Install gh cli tool for Fedora

### DIFF
--- a/provision/roles/packages/tasks/Fedora32.yml
+++ b/provision/roles/packages/tasks/Fedora32.yml
@@ -2,6 +2,13 @@
   set_fact:
     selinux_enabled: true
 
+- name: Enable GH cli repo
+  become: True
+  shell: |
+    dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo
+  args:
+    warn: false
+
 - name: Install common packages
   become: True
   dnf:
@@ -28,6 +35,7 @@
     - valgrind
     - vim
     - wget
+    - gh
 
 - name: Install IPA specific packages
   become: True


### PR DESCRIPTION
Not sure if this is something which will be accepted but I find the [GitHub CLI](https://cli.github.com/) tool quite useful, and would benefit from automatically having it installed on Fedora systems.