### PR TITLE
Fix 'ldap' vagrant box deployment

### DIFF
--- a/provision/roles/ldap/tasks/main.yml
+++ b/provision/roles/ldap/tasks/main.yml
@@ -15,3 +15,13 @@
   args:
     creates: '/etc/dirsrv/slapd-localhost'
 
+- name: Grant read-only anonymous access
+  become: True
+  shell: |
+    ldapmodify -D "{{ ldap.bind.dn }}" -w "{{ ldap.bind.password }}" -H ldap://localhost -x
+  args:
+    stdin: |
+      dn: {{ ldap.suffix }}
+      changetype: modify
+      add: aci
+      aci: (targetattr=*)(version 3.0; acl "Enable anyone read"; allow (read, search, compare)(userdn="ldap:///anyone");)

--- a/provision/roles/packages/tasks/Fedora35.yml
+++ b/provision/roles/packages/tasks/Fedora35.yml
@@ -53,6 +53,8 @@
     state: present
     name:
     - 389-ds-base
+    # https://bugzilla.redhat.com/show_bug.cgi?id=2057436
+    - acl
   when: inventory_hostname == 'ldap'
 
 - name: Install Client specific packages

--- a/provision/roles/packages/tasks/Fedora37.yml
+++ b/provision/roles/packages/tasks/Fedora37.yml
@@ -1,0 +1,2 @@
+- name: 'Packages are the same as in Fedora 36'
+  include_tasks: 'Fedora36.yml'


### PR DESCRIPTION
These changes allow a successful deployment of the `ldap` box for Fedora 36 + rawhide