### PR TITLE
provision: Remove 127.0.1.1 in /etc/hosts

### DIFF
--- a/provision/roles/ipa/tasks/main.yml
+++ b/provision/roles/ipa/tasks/main.yml
@@ -2,7 +2,7 @@
   become: True
   lineinfile:
     path: /etc/hosts
-    regexp: '^(127\.0\.0\.1|::1)[ \t]+{{ ipa.hostname }}.*$'
+    regexp: '^(127\.0\.[0-1]\.1|::1)[ \t]+{{ ipa.hostname }}.*$'
     state: absent
 
 - name: Install IPA server


### PR DESCRIPTION
On Fedora 36 (and later I suspect) the /etc/hosts entry gets added as `127.0.1.1 master.ipa.vm` instead of `127.0.0.1` This fix allows the installer to proceed past the initial failure to install IPA