### PR TITLE
Add support for number of cpus

### DIFF
--- a/configs/f32.json
+++ b/configs/f32.json
@@ -3,12 +3,14 @@
     "ad": {
       "name": "peru/windows-server-2019-datacenter-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ad-child": {
       "name": "peru/windows-server-2019-datacenter-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ipa": {
       "name": "fedora/32-cloud-base",

--- a/configs/sssd-f32.json
+++ b/configs/sssd-f32.json
@@ -3,12 +3,14 @@
     "ad": {
       "name": "peru/windows-server-2019-datacenter-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ad-child": {
       "name": "peru/windows-server-2019-datacenter-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ipa": {
       "name": "sssd-vagrant/fedora32-ipa",

--- a/configs/sssd-fedora-rawhide.json
+++ b/configs/sssd-fedora-rawhide.json
@@ -3,12 +3,14 @@
     "ad": {
       "name": "peru/windows-server-2019-standard-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ad-child": {
       "name": "peru/windows-server-2019-standard-x64-eval",
       "url": "",
-      "memory": 2048
+      "memory": 2048,
+      "cpus": 2
     },
     "ipa": {
       "name": "sssd-vagrant/fedora-rawhide-ipa",

--- a/ruby/config.rb
+++ b/ruby/config.rb
@@ -53,6 +53,16 @@ class Config
     return value
   end
 
+  def getCpus(name)
+    value = @config.dig("boxes", name, "cpus")
+
+    if value.nil?
+      return 1
+    end
+
+    return value
+  end
+
   def getFolders(type, env_var)
     if ENV.has_key?("SSSD_TEST_SUITE_BOX")
       if ENV["SSSD_TEST_SUITE_BOX"] == "yes"

--- a/ruby/guest.rb
+++ b/ruby/guest.rb
@@ -11,6 +11,7 @@ class Guest
 
       this.vm.provider :libvirt do |libvirt|
         libvirt.memory = machine.memory
+        libvirt.cpus = machine.cpus
         libvirt.storage_pool_name = "sssd-test-suite"
 
         # Creating new private networks requires system connection.

--- a/ruby/machine.rb
+++ b/ruby/machine.rb
@@ -1,7 +1,7 @@
 require_relative './config.rb'
 
 class Machine
-  attr_reader :name, :type, :hostname, :ip, :memory, :box, :url
+  attr_reader :name, :type, :hostname, :ip, :memory, :box, :url, :cpus
 
   LINUX   = 1
   WINDOWS = 2
@@ -14,7 +14,8 @@ class Machine
     memory: nil,
     box: nil,
     url: nil,
-    config: nil
+    config: nil,
+    cpus: nil
   )
     @name = name
     @type = type
@@ -23,11 +24,13 @@ class Machine
     @memory = memory
     @box = box
     @url = url
+    @cpus = cpus
 
     if not config.nil?
       @memory = if memory.nil? then config.getMemory(name) end
       @box = if box.nil? then config.getBox(type, name) end
       @url = if url.nil? then config.getBoxURL(name) end
+      @cpus = if cpus.nil? then config.getCpus(name) end
     end
   end
 end


### PR DESCRIPTION
With this patch we can easily specify number of cpu for VM. That is usable when we want to run more complex tasks in VM. Particularly for windows machine 1 cpu is not enough.